### PR TITLE
translate exceptions from C++ to Python

### DIFF
--- a/src/vosk.i
+++ b/src/vosk.i
@@ -18,6 +18,17 @@ namespace kaldi {
 %pybuffer_binary(const char *data, int len);
 %ignore KaldiRecognizer::AcceptWaveform(const short *sdata, int len);
 %ignore KaldiRecognizer::AcceptWaveform(const float *fdata, int len);
+%exception {
+  try {
+    $action
+  } catch (kaldi::KaldiFatalError &e) {
+    PyErr_SetString(PyExc_RuntimeError, const_cast<char*>(e.KaldiMessage()));
+    SWIG_fail;
+  } catch (std::exception &e) {
+    PyErr_SetString(PyExc_RuntimeError, const_cast<char*>(e.what()));
+    SWIG_fail;
+  }
+}
 #endif
 
 #if SWIGJAVA


### PR DESCRIPTION
Wrap each API call in a try/catch.
See http://www.swig.org/Doc4.0/Python.html#Python_nn44

Resolves #19 

With this change, the test code outputs the following:
```
+ /opt/python/cp37-cp37m/bin/python repro.py
vosk --min-active=200 --max-active=3000 --beam=10.0 --lattice-beam=2.0 --acoustic-scale=1.0 --frame-subsampling-factor=3 --endpoint.silence-phones=1:2:3:4:5:6:7:8:9:10 --endpoint.rule2.min-trailing-silence=0.5 --endpoint.rule3.min-trailing-silence=1.0 --endpoint.rule4.min-trailing-silence=2.0
LOG (vosk[5.5.599~1-11bed]:ComputeDerivedVars():ivector-extractor.cc:183) Computing derived variables for iVector extractor
LOG (vosk[5.5.599~1-11bed]:ComputeDerivedVars():ivector-extractor.cc:204) Done.
LOG (vosk[5.5.599~1-11bed]:RemoveOrphanNodes():nnet-nnet.cc:948) Removed 1 orphan nodes.
LOG (vosk[5.5.599~1-11bed]:RemoveOrphanComponents():nnet-nnet.cc:847) Removing 2 orphan components.
LOG (vosk[5.5.599~1-11bed]:Collapse():nnet-utils.cc:1472) Added 1 components, removed 2
LOG (vosk[5.5.599~1-11bed]:CompileLooped():nnet-compile-looped.cc:345) Spent 0.0184109 seconds in looped compilation.
ERROR (vosk[5.5.599~1-11bed]:MaybeCreateResampler():online-feature.cc:99) Sampling frequency mismatch, expected 16000, got 8000
Perhaps you want to use the options --allow_{upsample,downsample}

[ Stack-Trace: ]
/opt/python/cp37-cp37m/lib/python3.7/site-packages/vosk/_vosk.so(kaldi::MessageLogger::LogMessage() const+0x7a6) [0x7f34317bb3c6]
/opt/python/cp37-cp37m/lib/python3.7/site-packages/vosk/_vosk.so(kaldi::MessageLogger::LogAndThrow::operator=(kaldi::MessageLogger const&)+0x13) [0x7f343145c2a3]
/opt/python/cp37-cp37m/lib/python3.7/site-packages/vosk/_vosk.so(kaldi::OnlineGenericBaseFeature<kaldi::MfccComputer>::MaybeCreateResampler(float)+0x23a) [0x7f343166ca3e]
/opt/python/cp37-cp37m/lib/python3.7/site-packages/vosk/_vosk.so(kaldi::OnlineGenericBaseFeature<kaldi::MfccComputer>::AcceptWaveform(float, kaldi::VectorBase<float> const&)+0x55) [0x7f343166d413]
/opt/python/cp37-cp37m/lib/python3.7/site-packages/vosk/_vosk.so(kaldi::OnlineNnet2FeaturePipeline::AcceptWaveform(float, kaldi::VectorBase<float> const&)+0x1c) [0x7f34314aeb3a]
/opt/python/cp37-cp37m/lib/python3.7/site-packages/vosk/_vosk.so(KaldiRecognizer::AcceptWaveform(kaldi::Vector<float>&)+0x1c) [0x7f34314534ec]
/opt/python/cp37-cp37m/lib/python3.7/site-packages/vosk/_vosk.so(KaldiRecognizer::AcceptWaveform(char const*, int)+0x17e) [0x7f34314536ae]
/opt/python/cp37-cp37m/lib/python3.7/site-packages/vosk/_vosk.so(+0x223830) [0x7f3431452830]
/opt/python/cp37-cp37m/bin/python(_PyMethodDef_RawFastCallKeywords+0x2fa) [0x43a57a]
/opt/python/cp37-cp37m/bin/python(_PyCFunction_FastCallKeywords+0x2a) [0x43a62a]
/opt/python/cp37-cp37m/bin/python(_PyEval_EvalFrameDefault+0x7158) [0x426c18]
/opt/python/cp37-cp37m/bin/python() [0x41e993]
/opt/python/cp37-cp37m/bin/python(_PyEval_EvalFrameDefault+0x91ea) [0x428caa]
/opt/python/cp37-cp37m/bin/python(_PyEval_EvalCodeWithName+0x96c) [0x4e135c]
/opt/python/cp37-cp37m/bin/python(PyEval_EvalCode+0x23) [0x4e15a3]
/opt/python/cp37-cp37m/bin/python(PyRun_FileExFlags+0xb2) [0x512ab2]
/opt/python/cp37-cp37m/bin/python(PyRun_SimpleFileExFlags+0xe3) [0x512c33]
/opt/python/cp37-cp37m/bin/python() [0x42ecb1]
/opt/python/cp37-cp37m/bin/python(_Py_UnixMain+0x39) [0x42eec9]
/lib64/libc.so.6(__libc_start_main+0x100) [0x7f3431fead20]
/opt/python/cp37-cp37m/bin/python() [0x428d6d]

Exception! Sampling frequency mismatch, expected 16000, got 8000
Perhaps you want to use the options --allow_{upsample,downsample}
Traceback (most recent call last):
  File "repro.py", line 10, in <module>
    raise e
  File "repro.py", line 7, in <module>
    print(rec.AcceptWaveform(data))
  File "/opt/python/cp37-cp37m/lib/python3.7/site-packages/vosk/vosk.py", line 73, in AcceptWaveform
    return _vosk.KaldiRecognizer_AcceptWaveform(self, data)
RuntimeError: Sampling frequency mismatch, expected 16000, got 8000
Perhaps you want to use the options --allow_{upsample,downsample}
```