### PR TITLE
allow resampling to match model with input

### DIFF
--- a/python/example/test_local.py
+++ b/python/example/test_local.py
@@ -4,25 +4,37 @@ from vosk import Model, KaldiRecognizer
 import sys
 import json
 import os
+import wave
 
 if not os.path.exists("model"):
     print ("Please download the model from https://github.com/alphacep/kaldi-android-demo/releases and unpack as 'model' in the current folder.")
     exit (1)
 
 
+wf_name = sys.argv[1]
+wf = wave.open(wf_name, "rb")
+
+# check that the WAV is 16-bit mono
+assert 1 == wf.getnchannels()
+assert 2 == wf.getsampwidth()
+assert 'NONE' == wf.getcomptype()
+
 model = Model("model")
+if model.GetSampleFrequency() < wf.getframerate():
+    print('Model sample frequency is lower than WAV file. Enabling downsampling.')
+    model.SetAllowDownsample(True)
+elif model.GetSampleFrequency() > wf.getframerate():
+    print('Model sample frequency is higher than WAV file. Enabling upsampling. You may experience inaccurate results.')
+    model.SetAllowUpsample(True)
 
 # Large vocabulary free form recognition
-rec = KaldiRecognizer(model, 16000)
+rec = KaldiRecognizer(model, wf.getframerate())
 
 # You can also specify the possible word list
-#rec = KaldiRecognizer(model, 16000, "zero oh one two three four five six seven eight nine")
-
-wf = open(sys.argv[1], "rb")
-wf.read(44) # skip header
+# rec = KaldiRecognizer(model, wf.getframerate(), "zero oh one two three four five six seven eight nine")
 
 while True:
-    data = wf.read(2000)
+    data = wf.readframes(1000)
     if len(data) == 0:
         break
     if rec.AcceptWaveform(data):

--- a/src/model.cc
+++ b/src/model.cc
@@ -172,7 +172,7 @@ Model::~Model() {
     delete g_fst_;
 }
 
-float Model::GetSampleFrequency() const {
+int Model::SampleFrequency() const {
     return feature_info_.mfcc_opts.frame_opts.samp_freq;
 }
 

--- a/src/model.cc
+++ b/src/model.cc
@@ -86,6 +86,8 @@ Model::Model(const char *model_path) {
 
     feature_info_.feature_type = "mfcc";
     ReadConfigFromFile(model_path_str + "/mfcc.conf", &feature_info_.mfcc_opts);
+    feature_info_.mfcc_opts.frame_opts.allow_downsample = true;
+    feature_info_.mfcc_opts.frame_opts.allow_upsample = true;
 
     feature_info_.silence_weighting_config.silence_weight = 1e-3;
     feature_info_.silence_weighting_config.silence_phones_str = "1:2:3:4:5:6:7:8:9:10";

--- a/src/model.cc
+++ b/src/model.cc
@@ -86,8 +86,6 @@ Model::Model(const char *model_path) {
 
     feature_info_.feature_type = "mfcc";
     ReadConfigFromFile(model_path_str + "/mfcc.conf", &feature_info_.mfcc_opts);
-    feature_info_.mfcc_opts.frame_opts.allow_downsample = true;
-    feature_info_.mfcc_opts.frame_opts.allow_upsample = true;
 
     feature_info_.silence_weighting_config.silence_weight = 1e-3;
     feature_info_.silence_weighting_config.silence_phones_str = "1:2:3:4:5:6:7:8:9:10";
@@ -172,4 +170,16 @@ Model::~Model() {
     delete hclg_fst_;
     delete hcl_fst_;
     delete g_fst_;
+}
+
+float Model::GetSampleFrequency() const {
+    return feature_info_.mfcc_opts.frame_opts.samp_freq;
+}
+
+void Model::SetAllowDownsample(bool val) {
+    feature_info_.mfcc_opts.frame_opts.allow_downsample = val;
+}
+
+void Model::SetAllowUpsample(bool val) {
+    feature_info_.mfcc_opts.frame_opts.allow_upsample = val;
 }

--- a/src/model.h
+++ b/src/model.h
@@ -40,6 +40,9 @@ class Model {
 public:
     Model(const char *model_path);
     ~Model();
+    float GetSampleFrequency() const;
+    void SetAllowDownsample(bool val);
+    void SetAllowUpsample(bool val);
 
 protected:
     friend class KaldiRecognizer;

--- a/src/model.h
+++ b/src/model.h
@@ -40,7 +40,7 @@ class Model {
 public:
     Model(const char *model_path);
     ~Model();
-    float GetSampleFrequency() const;
+    int SampleFrequency() const;
     void SetAllowDownsample(bool val);
     void SetAllowUpsample(bool val);
 


### PR DESCRIPTION
Resolves #18 

With this change, the code in #18 which used trigger an exception, now works:
```
+ /opt/python/cp37-cp37m/bin/python repro.py
vosk --min-active=200 --max-active=3000 --beam=10.0 --lattice-beam=2.0 --acoustic-scale=1.0 --frame-subsampling-factor=3 --endpoint.silence-phones=1:2:3:4:5:6:7:8:9:10 --endpoint.rule2.min-trailing-silence=0.5 --endpoint.rule3.min-trailing-silence=1.0 --endpoint.rule4.min-trailing-silence=2.0
LOG (vosk[5.5.599~1-11bed]:ComputeDerivedVars():ivector-extractor.cc:183) Computing derived variables for iVector extractor
LOG (vosk[5.5.599~1-11bed]:ComputeDerivedVars():ivector-extractor.cc:204) Done.
LOG (vosk[5.5.599~1-11bed]:RemoveOrphanNodes():nnet-nnet.cc:948) Removed 1 orphan nodes.
LOG (vosk[5.5.599~1-11bed]:RemoveOrphanComponents():nnet-nnet.cc:847) Removing 2 orphan components.
LOG (vosk[5.5.599~1-11bed]:Collapse():nnet-utils.cc:1472) Added 1 components, removed 2
LOG (vosk[5.5.599~1-11bed]:CompileLooped():nnet-compile-looped.cc:345) Spent 0.0140388 seconds in looped compilation.
False
OK
```