### PR TITLE
Exposing vosk_recognizer_partial_result to nodejs library

### DIFF
--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -22,14 +22,15 @@ if (os.platform() === 'win32') {
 }
 
 const libvosk = ffi.Library(soname, {
-  'vosk_set_log_level': [ 'void', [ 'int' ] ],
-  'vosk_model_new': [ vosk_model_ptr, [ 'string' ] ],
-  'vosk_model_free': [ 'void', [ vosk_model_ptr ] ],
-  'vosk_recognizer_new': [ vosk_recognizer_ptr, [ vosk_model_ptr, 'float' ] ],
-  'vosk_recognizer_free': [ 'void', [ vosk_recognizer_ptr ] ],
-  'vosk_recognizer_accept_waveform': [ 'bool', [ vosk_recognizer_ptr, 'pointer', 'int' ] ],
-  'vosk_recognizer_result': ['string', [vosk_recognizer_ptr ] ],
-  'vosk_recognizer_final_result': ['string', [vosk_recognizer_ptr ] ],
+    'vosk_set_log_level': [ 'void', [ 'int' ] ],
+    'vosk_model_new': [ vosk_model_ptr, [ 'string' ] ],
+    'vosk_model_free': [ 'void', [ vosk_model_ptr ] ],
+    'vosk_recognizer_new': [ vosk_recognizer_ptr, [ vosk_model_ptr, 'float' ] ],
+    'vosk_recognizer_free': [ 'void', [ vosk_recognizer_ptr ] ],
+    'vosk_recognizer_accept_waveform': [ 'bool', [ vosk_recognizer_ptr, 'pointer', 'int' ] ],
+    'vosk_recognizer_result': [ 'string', [ vosk_recognizer_ptr ] ],
+    'vosk_recognizer_partial_result': [ 'string', [ vosk_recognizer_ptr ] ],
+    'vosk_recognizer_final_result': [ 'string', [ vosk_recognizer_ptr ] ],
 });
 
 function setLogLevel(level) {

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -12,10 +12,10 @@ const vosk_spk_model_ptr = ref.refType(vosk_spk_model);
 const vosk_recognizer = ref.types.void;
 const vosk_recognizer_ptr = ref.refType(vosk_recognizer);
 
-var soname;
-if (os.platform == 'win32') {
+let soname;
+if (os.platform() === 'win32') {
     soname = path.join(__dirname, "lib", "win-x86_64", "libvosk.dll")
-} else if (os.platform == 'darwin') {
+} else if (os.platform() === 'darwin') {
     soname = path.join(__dirname, "lib", "osx-x86_64", "libvosk.dylib")
 } else {
     soname = path.join(__dirname, "lib", "linux-x86_64", "libvosk.so")


### PR DESCRIPTION
As `Recognizer.partialResult` exposes `libvosk.vosk_recognizer_partial_result`, this method has to be exposed in `ffi.Library(...` as well.