### PR TITLE
Update ffi-napi and improve dependency to ref-napi

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -18,8 +18,8 @@
     "node": ">= 12.x.x"
   },
   "dependencies": {
-    "ffi-napi": "^3.1.0",
-    "ref-napi": "^3.0.0",
+    "ffi-napi": "^4.0.3",
+    "ref-napi": ">=2.0.0",
     "wav": "^1.0.2"
   }
 }


### PR DESCRIPTION
With this change, we will use the same version of ref-napi than the one declared in ffi-napi, which reduce dependency tree, bundle size, risks of errors that could be fixed in one version and not in the other, etc