### PR TITLE
Add n-best matches support

### DIFF
--- a/android/lib/src/main/java/org/vosk/LibVosk.java
+++ b/android/lib/src/main/java/org/vosk/LibVosk.java
@@ -31,9 +31,9 @@ public class LibVosk {
 
     public static native boolean vosk_recognizer_accept_waveform_f(Pointer recognizer, float[] data, int len);
 
-    public static native String vosk_recognizer_result(Pointer recognizer);
+    public static native String vosk_recognizer_result(Pointer recognizer, int nBestMatches);
 
-    public static native String vosk_recognizer_final_result(Pointer recognizer);
+    public static native String vosk_recognizer_final_result(Pointer recognizer, int nBestMatches);
 
     public static native String vosk_recognizer_partial_result(Pointer recognizer);
 

--- a/android/lib/src/main/java/org/vosk/Recognizer.java
+++ b/android/lib/src/main/java/org/vosk/Recognizer.java
@@ -3,6 +3,8 @@ package org.vosk;
 import com.sun.jna.PointerType;
 
 public class Recognizer extends PointerType implements AutoCloseable {
+    private static final int DEFAULT_N_BEST_MATCHES_DEPTH = 1;
+
     public Recognizer(Model model, float sampleRate) {
         super(LibVosk.vosk_recognizer_new(model, sampleRate));
     }
@@ -28,7 +30,11 @@ public class Recognizer extends PointerType implements AutoCloseable {
     }
 
     public String getResult() {
-        return LibVosk.vosk_recognizer_result(this.getPointer());
+        return getResult(DEFAULT_N_BEST_MATCHES_DEPTH);
+    }
+
+    public String getResult(int nBestMatches) {
+        return LibVosk.vosk_recognizer_result(this.getPointer(), nBestMatches);
     }
 
     public String getPartialResult() {
@@ -36,7 +42,11 @@ public class Recognizer extends PointerType implements AutoCloseable {
     }
 
     public String getFinalResult() {
-        return LibVosk.vosk_recognizer_final_result(this.getPointer());
+        return getFinalResult(DEFAULT_N_BEST_MATCHES_DEPTH);
+    }
+
+    public String getFinalResult(int nBestMatches) {
+        return LibVosk.vosk_recognizer_final_result(this.getPointer(), nBestMatches);
     }
 
     @Override

--- a/csharp/nuget/src/VoskPINVOKE.cs
+++ b/csharp/nuget/src/VoskPINVOKE.cs
@@ -42,13 +42,13 @@ class VoskPINVOKE {
   public static extern bool VoskRecognizer_AcceptWaveformFloat(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)]float[] jarg2, int jarg3);
 
   [global::System.Runtime.InteropServices.DllImport("libvosk", EntryPoint="vosk_recognizer_result")]
-  public static extern global::System.IntPtr VoskRecognizer_Result(global::System.Runtime.InteropServices.HandleRef jarg1);
+  public static extern global::System.IntPtr VoskRecognizer_Result(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
   [global::System.Runtime.InteropServices.DllImport("libvosk", EntryPoint="vosk_recognizer_partial_result")]
   public static extern global::System.IntPtr VoskRecognizer_PartialResult(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("libvosk", EntryPoint="vosk_recognizer_final_result")]
-  public static extern global::System.IntPtr VoskRecognizer_FinalResult(global::System.Runtime.InteropServices.HandleRef jarg1);
+  public static extern global::System.IntPtr VoskRecognizer_FinalResult(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
   [global::System.Runtime.InteropServices.DllImport("libvosk", EntryPoint="vosk_set_log_level")]
   public static extern void SetLogLevel(int jarg1);

--- a/csharp/nuget/src/VoskRecognizer.cs
+++ b/csharp/nuget/src/VoskRecognizer.cs
@@ -2,6 +2,7 @@ namespace Vosk {
 
 public class VoskRecognizer : global::System.IDisposable {
   private global::System.Runtime.InteropServices.HandleRef handle;
+  private const int DEFAULT_N_BEST_MATCHES_DEPTH = 1;
 
   internal VoskRecognizer(global::System.IntPtr cPtr) {
     handle = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
@@ -51,7 +52,11 @@ public class VoskRecognizer : global::System.IDisposable {
   }
 
   public string Result() {
-    return global::System.Runtime.InteropServices.Marshal.PtrToStringUTF8(VoskPINVOKE.VoskRecognizer_Result(handle));
+    return Result(DEFAULT_N_BEST_MATCHES_DEPTH);
+  }
+
+  public string Result(int nBestMatches) {
+    return global::System.Runtime.InteropServices.Marshal.PtrToStringUTF8(VoskPINVOKE.VoskRecognizer_Result(handle, nBestMatches));
   }
 
   public string PartialResult() {
@@ -59,7 +64,11 @@ public class VoskRecognizer : global::System.IDisposable {
   }
 
   public string FinalResult() {
-    return global::System.Runtime.InteropServices.Marshal.PtrToStringUTF8(VoskPINVOKE.VoskRecognizer_FinalResult(handle));
+    return FinalResult(DEFAULT_N_BEST_MATCHES_DEPTH);
+  }
+
+  public string FinalResult(int nBestMatches) {
+    return global::System.Runtime.InteropServices.Marshal.PtrToStringUTF8(VoskPINVOKE.VoskRecognizer_FinalResult(handle, nBestMatches));
   }
 
 }

--- a/java/lib/src/main/java/org/vosk/LibVosk.java
+++ b/java/lib/src/main/java/org/vosk/LibVosk.java
@@ -33,9 +33,9 @@ public class LibVosk {
 
     public static native boolean vosk_recognizer_accept_waveform_f(Pointer recognizer, float[] data, int len);
 
-    public static native String vosk_recognizer_result(Pointer recognizer);
+    public static native String vosk_recognizer_result(Pointer recognizer, int nBestMatches);
 
-    public static native String vosk_recognizer_final_result(Pointer recognizer);
+    public static native String vosk_recognizer_final_result(Pointer recognizer, int nBestMatches);
 
     public static native String vosk_recognizer_partial_result(Pointer recognizer);
 

--- a/java/lib/src/main/java/org/vosk/Recognizer.java
+++ b/java/lib/src/main/java/org/vosk/Recognizer.java
@@ -3,6 +3,8 @@ package org.vosk;
 import com.sun.jna.PointerType;
 
 public class Recognizer extends PointerType implements AutoCloseable {
+    private static final int DEFAULT_N_BEST_MATCHES_DEPTH = 1;
+
     public Recognizer(Model model, float sampleRate) {
         super(LibVosk.vosk_recognizer_new(model, sampleRate));
     }
@@ -28,7 +30,11 @@ public class Recognizer extends PointerType implements AutoCloseable {
     }
 
     public String getResult() {
-        return LibVosk.vosk_recognizer_result(this.getPointer());
+        return getResult(DEFAULT_N_BEST_MATCHES_DEPTH);
+    }
+
+    public String getResult(int nBestMatches) {
+        return LibVosk.vosk_recognizer_result(this.getPointer(), nBestMatches);
     }
 
     public String getPartialResult() {
@@ -36,7 +42,11 @@ public class Recognizer extends PointerType implements AutoCloseable {
     }
 
     public String getFinalResult() {
-        return LibVosk.vosk_recognizer_final_result(this.getPointer());
+        return getFinalResult(DEFAULT_N_BEST_MATCHES_DEPTH);
+    }
+
+    public String getFinalResult(int nBestMatches) {
+        return LibVosk.vosk_recognizer_final_result(this.getPointer(), nBestMatches);
     }
 
     @Override

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -274,34 +274,29 @@ class Recognizer {
      *
      * @param {number} nBestMatches the amount of best matches retured back in result
      * @returns the result in JSON format which contains decoded line, decoded
-     *          words, times in seconds and confidences. You can parse this result
-     *          with any json parser. An optional bBestMatches arg allows managing
-     *          the depth of the best matches array
+     *          words and times in seconds. You can parse this result with any
+     *          json parser. An optional bBestMatches arg allows managing the 
+     *          depth of the best matches array
      * <pre>
      *  {
      *    "result" : [{
      *      "matches" : [{
-     *          "conf" : 1.000000,
      *          "end" : 1.110000,
      *          "start" : 0.870000,
      *          "word" : "what"
      *      }, {
-     *          "conf" : 1.000000,
      *          "end" : 1.530000,
      *          "start" : 1.110000,
      *          "word" : "zero"
      *      }, {
-     *          "conf" : 1.000000,
      *          "end" : 1.950000,
      *          "start" : 1.530000,
      *          "word" : "zero"
      *      }, {
-     *          "conf" : 1.000000,
      *          "end" : 2.340000,
      *          "start" : 1.950000,
      *          "word" : "zero"
      *      }, {
-     *          "conf" : 1.000000,
      *          "end" : 2.610000,
      *          "start" : 2.340000,
      *          "word" : "one"

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -87,8 +87,8 @@ const libvosk = ffi.Library(soname, {
     'vosk_recognizer_new_grm': [vosk_recognizer_ptr, [vosk_model_ptr, 'float', 'string']],
     'vosk_recognizer_free': ['void', [vosk_recognizer_ptr]],
     'vosk_recognizer_accept_waveform': ['bool', [vosk_recognizer_ptr, 'pointer', 'int']],
-    'vosk_recognizer_result': ['string', [vosk_recognizer_ptr]],
-    'vosk_recognizer_final_result': ['string', [vosk_recognizer_ptr]],
+    'vosk_recognizer_result': ['string', [vosk_recognizer_ptr, 'int']],
+    'vosk_recognizer_final_result': ['string', [vosk_recognizer_ptr, 'int']],
     'vosk_recognizer_partial_result': ['string', [vosk_recognizer_ptr]],
 });
 
@@ -272,43 +272,47 @@ class Recognizer {
 
     /** Returns speech recognition result in a string
      *
+     * @param {number} nBestMatches the amount of best matches retured back in result
      * @returns the result in JSON format which contains decoded line, decoded
      *          words, times in seconds and confidences. You can parse this result
-     *          with any json parser
+     *          with any json parser. An optional bBestMatches arg allows managing
+     *          the depth of the best matches array
      * <pre>
-     * {
-     *   "result" : [{
-     *       "conf" : 1.000000,
-     *       "end" : 1.110000,
-     *       "start" : 0.870000,
-     *       "word" : "what"
-     *     }, {
-     *       "conf" : 1.000000,
-     *       "end" : 1.530000,
-     *       "start" : 1.110000,
-     *       "word" : "zero"
-     *     }, {
-     *       "conf" : 1.000000,
-     *       "end" : 1.950000,
-     *       "start" : 1.530000,
-     *       "word" : "zero"
-     *     }, {
-     *       "conf" : 1.000000,
-     *       "end" : 2.340000,
-     *       "start" : 1.950000,
-     *       "word" : "zero"
-     *     }, {
-     *       "conf" : 1.000000,
-     *      "end" : 2.610000,
-     *       "start" : 2.340000,
-     *       "word" : "one"
-     *     }],
-     *   "text" : "what zero zero zero one"
+     *  {
+     *    "result" : [{
+     *      "matches" : [{
+     *          "conf" : 1.000000,
+     *          "end" : 1.110000,
+     *          "start" : 0.870000,
+     *          "word" : "what"
+     *      }, {
+     *          "conf" : 1.000000,
+     *          "end" : 1.530000,
+     *          "start" : 1.110000,
+     *          "word" : "zero"
+     *      }, {
+     *          "conf" : 1.000000,
+     *          "end" : 1.950000,
+     *          "start" : 1.530000,
+     *          "word" : "zero"
+     *      }, {
+     *          "conf" : 1.000000,
+     *          "end" : 2.340000,
+     *          "start" : 1.950000,
+     *          "word" : "zero"
+     *      }, {
+     *          "conf" : 1.000000,
+     *          "end" : 2.610000,
+     *          "start" : 2.340000,
+     *          "word" : "one"
+     *      }],
+     *      "text" : "what zero zero zero one"
+     *    }]
      *  }
      * </pre>
      */
-    resultString() {
-        return libvosk.vosk_recognizer_result(this.handle);
+    resultString(nBestMatches = 1) {
+        return libvosk.vosk_recognizer_result(this.handle, nBestMatches);
     };
 
     /**
@@ -316,7 +320,7 @@ class Recognizer {
      * @returns {Result<T>} The results
      */
     result() {
-        return JSON.parse(libvosk.vosk_recognizer_result(this.handle));
+        return JSON.parse(this.resultString());
     };
 
     /**
@@ -334,10 +338,11 @@ class Recognizer {
      * You usually call it in the end of the stream to get final bits of audio. It
      * flushes the feature pipeline, so all remaining audio chunks got processed.
      *
+     * @param {number} nBestMatches the amount of best matches retured back in result
      * @returns {Result<T>} speech result.
      */
-    finalResult() {
-        return JSON.parse(libvosk.vosk_recognizer_final_result(this.handle));
+    finalResult(nBestMatches = 1) {
+        return JSON.parse(libvosk.vosk_recognizer_final_result(this.handle, nBestMatches));
     };
 }
 

--- a/python/vosk/__init__.py
+++ b/python/vosk/__init__.py
@@ -57,14 +57,14 @@ class KaldiRecognizer(object):
     def AcceptWaveform(self, data):
         return _c.vosk_recognizer_accept_waveform(self._handle, data, len(data))
 
-    def Result(self):
-        return _ffi.string(_c.vosk_recognizer_result(self._handle)).decode('utf-8')
+    def Result(self, n_best_matches=1):
+        return _ffi.string(_c.vosk_recognizer_result(self._handle, n_best_matches)).decode('utf-8')
 
     def PartialResult(self):
         return _ffi.string(_c.vosk_recognizer_partial_result(self._handle)).decode('utf-8')
 
-    def FinalResult(self):
-        return _ffi.string(_c.vosk_recognizer_final_result(self._handle)).decode('utf-8')
+    def FinalResult(self, n_best_matches=1):
+        return _ffi.string(_c.vosk_recognizer_final_result(self._handle, n_best_matches)).decode('utf-8')
 
 
 def SetLogLevel(level):

--- a/src/kaldi_recognizer.cc
+++ b/src/kaldi_recognizer.cc
@@ -445,10 +445,6 @@ const char* KaldiRecognizer::GetResult(int nBestMatches)
                 continue;
             }
 
-            // We still require it for getting words' confidence.
-            MinimumBayesRisk mbr(nbest_clat);
-            const vector<BaseFloat> &conf = mbr.GetOneBestConfidences();
-
             json::JSON matches;
             stringstream text;
 
@@ -464,7 +460,6 @@ const char* KaldiRecognizer::GetResult(int nBestMatches)
                 word["word"] = foundWord;
                 word["start"] = start;
                 word["end"] = start + samples_round_start_ / sample_frequency_ + (frame_offset_ + lengths[j]) * 0.03;
-                word["conf"] = conf[j];
                 matches["matches"].append(word);
 
                 if (j) {

--- a/src/kaldi_recognizer.h
+++ b/src/kaldi_recognizer.h
@@ -48,8 +48,8 @@ class KaldiRecognizer {
         bool AcceptWaveform(const char *data, int len);
         bool AcceptWaveform(const short *sdata, int len);
         bool AcceptWaveform(const float *fdata, int len);
-        const char* Result();
-        const char* FinalResult();
+        const char* Result(int nBestMatches = 1);
+        const char* FinalResult(int nBestMatches = 1);
         const char* PartialResult();
 
     private:
@@ -59,7 +59,7 @@ class KaldiRecognizer {
         void UpdateSilenceWeights();
         bool AcceptWaveform(Vector<BaseFloat> &wdata);
         bool GetSpkVector(Vector<BaseFloat> &out_xvector, int *frames);
-        const char *GetResult();
+        const char *GetResult(int nBestMatches = 1);
         const char *StoreReturn(const string &res);
 
         Model *model_;

--- a/src/vosk_api.cc
+++ b/src/vosk_api.cc
@@ -80,9 +80,9 @@ int vosk_recognizer_accept_waveform_f(VoskRecognizer *recognizer, const float *d
     return ((KaldiRecognizer *)(recognizer))->AcceptWaveform(data, length);
 }
 
-const char *vosk_recognizer_result(VoskRecognizer *recognizer)
+const char *vosk_recognizer_result(VoskRecognizer *recognizer, int nBestMatches)
 {
-    return ((KaldiRecognizer *)recognizer)->Result();
+    return ((KaldiRecognizer *)recognizer)->Result(nBestMatches);
 }
 
 const char *vosk_recognizer_partial_result(VoskRecognizer *recognizer)
@@ -90,9 +90,9 @@ const char *vosk_recognizer_partial_result(VoskRecognizer *recognizer)
     return ((KaldiRecognizer *)recognizer)->PartialResult();
 }
 
-const char *vosk_recognizer_final_result(VoskRecognizer *recognizer)
+const char *vosk_recognizer_final_result(VoskRecognizer *recognizer, int nBestMatches)
 {
-    return ((KaldiRecognizer *)recognizer)->FinalResult();
+    return ((KaldiRecognizer *)recognizer)->FinalResult(nBestMatches);
 }
 
 void vosk_recognizer_free(VoskRecognizer *recognizer)

--- a/src/vosk_api.h
+++ b/src/vosk_api.h
@@ -136,43 +136,47 @@ int vosk_recognizer_accept_waveform_f(VoskRecognizer *recognizer, const float *d
 
 /** Returns speech recognition result
  *
+ * @param nBestMatches - the amount of best matches retured back in result
  * @returns the result in JSON format which contains decoded line, decoded
  *          words, times in seconds and confidences. You can parse this result
- *          with any json parser
+ *          with any json parser. An optional bBestMatches arg allows managing
+ *          the depth of the best matches array
  *
  * <pre>
  * {
  *   "result" : [{
- *       "conf" : 1.000000,
- *       "end" : 1.110000,
- *       "start" : 0.870000,
- *       "word" : "what"
- *     }, {
- *       "conf" : 1.000000,
- *       "end" : 1.530000,
- *       "start" : 1.110000,
- *       "word" : "zero"
- *     }, {
- *       "conf" : 1.000000,
- *       "end" : 1.950000,
- *       "start" : 1.530000,
- *       "word" : "zero"
- *     }, {
- *       "conf" : 1.000000,
- *       "end" : 2.340000,
- *       "start" : 1.950000,
- *       "word" : "zero"
- *     }, {
- *       "conf" : 1.000000,
- *      "end" : 2.610000,
- *       "start" : 2.340000,
- *       "word" : "one"
- *     }],
- *   "text" : "what zero zero zero one"
+ *      "matches" : [{
+ *        "conf" : 1.000000,
+ *        "end" : 1.110000,
+ *        "start" : 0.870000,
+ *        "word" : "what"
+ *      }, {
+ *        "conf" : 1.000000,
+ *        "end" : 1.530000,
+ *        "start" : 1.110000,
+ *        "word" : "zero"
+ *      }, {
+ *        "conf" : 1.000000,
+ *        "end" : 1.950000,
+ *        "start" : 1.530000,
+ *        "word" : "zero"
+ *      }, {
+ *        "conf" : 1.000000,
+ *        "end" : 2.340000,
+ *        "start" : 1.950000,
+ *        "word" : "zero"
+ *      }, {
+ *        "conf" : 1.000000,
+ *        "end" : 2.610000,
+ *        "start" : 2.340000,
+ *        "word" : "one"
+ *      }],
+ *      "text" : "what zero zero zero one",
+ *    }]
  *  }
  * </pre>
  */
-const char *vosk_recognizer_result(VoskRecognizer *recognizer);
+const char *vosk_recognizer_result(VoskRecognizer *recognizer, int nBestMatches = 1);
 
 
 /** Returns partial speech recognition
@@ -195,7 +199,7 @@ const char *vosk_recognizer_partial_result(VoskRecognizer *recognizer);
  *
  *  @returns speech result in JSON format.
  */
-const char *vosk_recognizer_final_result(VoskRecognizer *recognizer);
+const char *vosk_recognizer_final_result(VoskRecognizer *recognizer, int nBestMatches = 1);
 
 
 /** Releases recognizer object

--- a/src/vosk_api.h
+++ b/src/vosk_api.h
@@ -138,35 +138,30 @@ int vosk_recognizer_accept_waveform_f(VoskRecognizer *recognizer, const float *d
  *
  * @param nBestMatches - the amount of best matches retured back in result
  * @returns the result in JSON format which contains decoded line, decoded
- *          words, times in seconds and confidences. You can parse this result
- *          with any json parser. An optional bBestMatches arg allows managing
- *          the depth of the best matches array
+ *          words and times in seconds. You can parse this result with any
+ *          json parser. An optional bBestMatches arg allows managing the 
+ *          depth of the best matches array
  *
  * <pre>
  * {
  *   "result" : [{
  *      "matches" : [{
- *        "conf" : 1.000000,
  *        "end" : 1.110000,
  *        "start" : 0.870000,
  *        "word" : "what"
  *      }, {
- *        "conf" : 1.000000,
  *        "end" : 1.530000,
  *        "start" : 1.110000,
  *        "word" : "zero"
  *      }, {
- *        "conf" : 1.000000,
  *        "end" : 1.950000,
  *        "start" : 1.530000,
  *        "word" : "zero"
  *      }, {
- *        "conf" : 1.000000,
  *        "end" : 2.340000,
  *        "start" : 1.950000,
  *        "word" : "zero"
  *      }, {
- *        "conf" : 1.000000,
  *        "end" : 2.610000,
  *        "start" : 2.340000,
  *        "word" : "one"


### PR DESCRIPTION
Added an option of getting n-best results in a final json. By default, we leave depth = 1 for backward compatibility.

Fixes #76