### PR TITLE
Add phoneme content of words in the final results

### DIFF
--- a/src/model.cc
+++ b/src/model.cc
@@ -157,6 +157,7 @@ void Model::ConfigureV1()
     disambig_rxfilename_ = model_path_str_ + "/disambig_tid.int";
     word_syms_rxfilename_ = model_path_str_ + "/words.txt";
     winfo_rxfilename_ = model_path_str_ + "/word_boundary.int";
+    phone_syms_rxfilename_ = model_path_str_ + "/phones.txt";
     carpa_rxfilename_ = model_path_str_ + "/rescore/G.carpa";
     std_fst_rxfilename_ = model_path_str_ + "/rescore/G.fst";
     final_ie_rxfilename_ = model_path_str_ + "/ivector/final.ie";
@@ -173,7 +174,6 @@ void Model::ConfigureV2()
     decodable_opts_.Register(&po);
     po.ReadConfigFile(model_path_str_ + "/conf/model.conf");
 
-
     nnet3_rxfilename_ = model_path_str_ + "/am/final.mdl";
     hclg_fst_rxfilename_ = model_path_str_ + "/graph/HCLG.fst";
     hcl_fst_rxfilename_ = model_path_str_ + "/graph/HCLr.fst";
@@ -181,6 +181,7 @@ void Model::ConfigureV2()
     disambig_rxfilename_ = model_path_str_ + "/graph/disambig_tid.int";
     word_syms_rxfilename_ = model_path_str_ + "/graph/words.txt";
     winfo_rxfilename_ = model_path_str_ + "/graph/phones/word_boundary.int";
+    phone_syms_rxfilename_ = model_path_str_ + "/graph/phones.txt";
     carpa_rxfilename_ = model_path_str_ + "/rescore/G.carpa";
     std_fst_rxfilename_ = model_path_str_ + "/rescore/G.fst";
     final_ie_rxfilename_ = model_path_str_ + "/ivector/final.ie";
@@ -286,6 +287,16 @@ void Model::ReadDataFiles()
         winfo_ = NULL;
     }
 
+    phone_syms_ = NULL;
+    phone_syms_loaded_ = false;
+    if (stat(phone_syms_rxfilename_.c_str(), &buffer) == 0) {
+        KALDI_LOG << "Loading phones from " << phone_syms_rxfilename_;
+        if (!(phone_syms_ = fst::SymbolTable::ReadText(phone_syms_rxfilename_)))
+            KALDI_ERR << "Could not read phone symbol table from file "
+                      << phone_syms_rxfilename_;
+        phone_syms_loaded_ = word_syms_;
+    }
+
     std_lm_fst_ = NULL;
     if (stat(carpa_rxfilename_.c_str(), &buffer) == 0) {
         KALDI_LOG << "Loading CARPA model from " << carpa_rxfilename_;
@@ -327,6 +338,8 @@ Model::~Model() {
     if (word_syms_loaded_)
         delete word_syms_;
     delete winfo_;
+    if (phone_syms_loaded_)
+        delete phone_syms_;
     delete hclg_fst_;
     delete hcl_fst_;
     delete g_fst_;

--- a/src/model.h
+++ b/src/model.h
@@ -60,6 +60,7 @@ protected:
     string disambig_rxfilename_;
     string word_syms_rxfilename_;
     string winfo_rxfilename_;
+    string phone_syms_rxfilename_;
     string carpa_rxfilename_;
     string std_fst_rxfilename_;
     string final_ie_rxfilename_;
@@ -79,6 +80,8 @@ protected:
     bool word_syms_loaded_;
     kaldi::WordBoundaryInfo *winfo_;
     vector<int32> disambig_;
+    const fst::SymbolTable *phone_syms_;
+    bool phone_syms_loaded_;
 
     fst::Fst<fst::StdArc> *hclg_fst_;
     fst::Fst<fst::StdArc> *hcl_fst_;


### PR DESCRIPTION
This PR adds phoneme content of every word in the final result, given that `phones.txt` file is present in the model's graph dir. Example:

    {
      "result" : [{
          "conf" : 0.485717,
          "end" : 6.536367,
          "phones" : "s_B e_E",
          "start" : 6.240041,
          "word" : "see"
        }, {
          "conf" : 0.833751,
          "end" : 6.869995,
          "phones" : "o_B nn_E",
          "start" : 6.735288,
          "word" : "on"
        }, ...

Unfortunately there is a side effect: in order this to work, MBR decoding had to be disabled. We still get confidence scores for words, but the produced hypothesis is now based on the best path through the lattice, not MBR decoding. I don't think the two features (MBR decoding and phoneme content of words) can work together. Therefore I understand if this PR is not merged to the main branch.