### PR TITLE
Added script to compute phoneme labels and timestamps

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,7 +1,7 @@
 CFLAGS=-I../src
 LDFLAGS=-L../src -lvosk -ldl -lpthread -Wl,-rpath=../src
 
-all: test_vosk test_vosk_speaker
+all: test_vosk test_vosk_speaker test_phone_results
 
 test_vosk: test_vosk.o
 	g++ $^ -o $@ $(LDFLAGS)
@@ -9,8 +9,10 @@ test_vosk: test_vosk.o
 test_vosk_speaker: test_vosk_speaker.o
 	g++ $^ -o $@ $(LDFLAGS)
 
+test_phone_results: test_phone_results.o
+	g++ $^ -o $@ $(LDFLAGS)
 %.o: %.c
 	g++ $(CFLAGS) -c -o $@ $<
 
 clean:
-	rm -f *.o *.a test_vosk test_vosk_speaker
+	rm -f *.o *.a test_vosk test_vosk_speaker test_phone_results

--- a/c/test_phone_results.c
+++ b/c/test_phone_results.c
@@ -1,0 +1,30 @@
+#include <vosk_api.h>
+#include <stdio.h>
+
+int main() {
+    FILE *wavin;
+    char buf[3200];
+    int nread, final;
+
+    VoskModel *model = vosk_model_new("model");
+    VoskRecognizer *recognizer = vosk_recognizer_new(model, 16000.0);
+    vosk_recognizer_set_result_opts(recognizer, "phones");
+
+    wavin = fopen("test.wav", "rb");
+    fseek(wavin, 44, SEEK_SET);
+    while (!feof(wavin)) {
+         nread = fread(buf, 1, sizeof(buf), wavin);
+         final = vosk_recognizer_accept_waveform(recognizer, buf, nread);
+         if (final) {
+             printf("%s\n", vosk_recognizer_result(recognizer));
+         } else {
+             printf("%s\n", vosk_recognizer_partial_result(recognizer));
+         }
+    }
+    printf("%s\n", vosk_recognizer_final_result(recognizer));
+
+    vosk_recognizer_free(recognizer);
+    vosk_model_free(model);
+    fclose(wavin);
+    return 0;
+}

--- a/c/test_phone_results.c
+++ b/c/test_phone_results.c
@@ -8,7 +8,7 @@ int main() {
 
     VoskModel *model = vosk_model_new("model");
     VoskRecognizer *recognizer = vosk_recognizer_new(model, 16000.0);
-    vosk_recognizer_set_result_opts(recognizer, "phones");
+    vosk_recognizer_set_result_options(recognizer, "phones");
 
     wavin = fopen("test.wav", "rb");
     fseek(wavin, 44, SEEK_SET);

--- a/src/kaldi_recognizer.h
+++ b/src/kaldi_recognizer.h
@@ -47,6 +47,7 @@ class KaldiRecognizer {
         KaldiRecognizer(Model *model, float sample_frequency, char const *grammar);
         ~KaldiRecognizer();
         void SetMaxAlternatives(int max_alternatives);
+        void SetResultOptions(const char *result_opts);
         void SetSpkModel(SpkModel *spk_model);
         void SetWords(bool words);
         bool AcceptWaveform(const char *data, int len);
@@ -56,7 +57,7 @@ class KaldiRecognizer {
         const char* FinalResult();
         const char* PartialResult();
         void Reset();
-
+        
     private:
         void InitState();
         void InitRescoring();
@@ -93,6 +94,7 @@ class KaldiRecognizer {
 
         // Other
         int max_alternatives_ = 0; // Disable alternatives by default
+        const char *result_opts_ = "words"; // By default enable only word-level results
         bool words_ = false;
 
         float sample_frequency_;

--- a/src/model.cc
+++ b/src/model.cc
@@ -292,7 +292,7 @@ void Model::ReadDataFiles()
         word_syms_ = g_fst_->OutputSymbols();
     }
     if (!word_syms_) {
-        KALDI_LOG << "Loading words from xxxx" << word_syms_rxfilename_;
+        KALDI_LOG << "Loading words from " << word_syms_rxfilename_;
         if (!(word_syms_ = fst::SymbolTable::ReadText(word_syms_rxfilename_)))
             KALDI_ERR << "Could not read symbol table from file "
                       << word_syms_rxfilename_;

--- a/src/model.cc
+++ b/src/model.cc
@@ -175,6 +175,7 @@ void Model::ConfigureV1()
     rnnlm_feat_embedding_rxfilename_ = model_path_str_ + "/rnnlm/feat_embedding.final.mat";
     rnnlm_config_rxfilename_ = model_path_str_ + "/rnnlm/special_symbol_opts.conf";
     rnnlm_lm_rxfilename_ = model_path_str_ + "/rnnlm/final.raw";
+    phone_syms_rxfilename_ = model_path_str_ + "/graph/phones.txt";
 }
 
 void Model::ConfigureV2()
@@ -204,6 +205,7 @@ void Model::ConfigureV2()
     rnnlm_feat_embedding_rxfilename_ = model_path_str_ + "/rnnlm/feat_embedding.final.mat";
     rnnlm_config_rxfilename_ = model_path_str_ + "/rnnlm/special_symbol_opts.conf";
     rnnlm_lm_rxfilename_ = model_path_str_ + "/rnnlm/final.raw";
+    phone_syms_rxfilename_ = model_path_str_ + "/graph/phones.txt";
 }
 
 void Model::ReadDataFiles()
@@ -290,7 +292,7 @@ void Model::ReadDataFiles()
         word_syms_ = g_fst_->OutputSymbols();
     }
     if (!word_syms_) {
-        KALDI_LOG << "Loading words from " << word_syms_rxfilename_;
+        KALDI_LOG << "Loading words from xxxx" << word_syms_rxfilename_;
         if (!(word_syms_ = fst::SymbolTable::ReadText(word_syms_rxfilename_)))
             KALDI_ERR << "Could not read symbol table from file "
                       << word_syms_rxfilename_;
@@ -302,6 +304,16 @@ void Model::ReadDataFiles()
         KALDI_LOG << "Loading winfo " << winfo_rxfilename_;
         kaldi::WordBoundaryInfoNewOpts opts;
         winfo_ = new kaldi::WordBoundaryInfo(opts, winfo_rxfilename_);
+    }
+
+    phone_symbol_table_ = NULL;
+    phone_syms_loaded_ = false;
+    //Providing phones.txt symbol table is optional and currently not required by Vosk
+    //If you provide it by default the phone information will be computed
+    if (stat(phone_syms_rxfilename_.c_str(), &buffer) == 0) {
+        KALDI_LOG << "Loading phonemes from " << phone_syms_rxfilename_;
+        phone_symbol_table_  = fst::SymbolTable::ReadText(phone_syms_rxfilename_);
+        phone_syms_loaded_ = true;
     }
 
     if (stat(carpa_rxfilename_.c_str(), &buffer) == 0) {

--- a/src/model.h
+++ b/src/model.h
@@ -69,6 +69,7 @@ protected:
     string fbank_conf_rxfilename_;
     string global_cmvn_stats_rxfilename_;
     string pitch_conf_rxfilename_;
+    string phone_syms_rxfilename_;
 
     string rnnlm_word_feats_rxfilename_;
     string rnnlm_feat_embedding_rxfilename_;
@@ -87,6 +88,8 @@ protected:
     bool word_syms_loaded_ = false;
     kaldi::WordBoundaryInfo *winfo_ = nullptr;
     vector<int32> disambig_;
+    const fst::SymbolTable *phone_symbol_table_;
+    bool phone_syms_loaded_;
 
     fst::Fst<fst::StdArc> *hclg_fst_ = nullptr;
     fst::Fst<fst::StdArc> *hcl_fst_ = nullptr;

--- a/src/vosk_api.cc
+++ b/src/vosk_api.cc
@@ -96,6 +96,11 @@ void vosk_recognizer_set_max_alternatives(VoskRecognizer *recognizer, int max_al
     ((KaldiRecognizer *)recognizer)->SetMaxAlternatives(max_alternatives);
 }
 
+void vosk_recognizer_set_result_options(VoskRecognizer *recognizer, const char *result_opts)
+{
+    ((KaldiRecognizer *)recognizer)->SetResultOptions(result_opts);
+}
+
 void vosk_recognizer_set_words(VoskRecognizer *recognizer, int words)
 {
     ((KaldiRecognizer *)recognizer)->SetWords((bool)words);

--- a/src/vosk_api.h
+++ b/src/vosk_api.h
@@ -150,6 +150,84 @@ void vosk_recognizer_set_spk_model(VoskRecognizer *recognizer, VoskSpkModel *spk
  */
 void vosk_recognizer_set_max_alternatives(VoskRecognizer *recognizer, int max_alternatives);
 
+/** Configures recognizer result options (i.e. whether to print word-level results or word and phone level results together)
+ * With phone level results (i.e. if configured with "phones" option)
+ * <pre>
+ *    {
+ *     "result" : [{
+ *         "conf" : 0.998335,
+ *         "end" : 0.450000,
+ *         "phone_end" : [0.450000],
+ *         "phone_label" : ["SIL"],
+ *         "phone_start" : [0.000000],
+ *         "start" : 0.000000,
+ *         "word" : "<eps>"
+ *       }, {
+ *         "conf" : 0.998324,
+ *         "end" : 0.600000,
+ *         "phone_end" : [0.540000, 0.600000],
+ *         "phone_label" : ["DH_B", "AH1_E"],
+ *         "phone_start" : [0.450000, 0.540000],
+ *         "start" : 0.450000,
+ *         "word" : "THE"
+ *       }, {
+ *         "conf" : 0.574095,
+ *         "end" : 1.200000,
+ *         "phone_end" : [0.720000, 0.810000, 0.870000, 0.930000, 0.990000, 1.080000, 1.110000, 1.200000],
+ *         "phone_label" : ["S_B", "T_I", "UW1_I", "D_I", "AH0_I", "N_I", "T_I", "S_E"],
+ *         "phone_start" : [0.600000, 0.720000, 0.810000, 0.870000, 0.930000, 0.990000, 1.080000, 1.110000],
+ *         "start" : 0.600000,
+ *         "word" : "STUDENT'S"
+ *       }, {
+ *         "conf" : 0.923344,
+ *         "end" : 1.260000,
+ *         "phone_end" : [1.260111],
+ *         "phone_label" : ["SIL"],
+ *         "phone_start" : [1.200111],
+ *         "start" : 1.200111,
+ *         "word" : "<eps>"
+ *       }, {
+ *         "conf" : 1.000000,
+ *         "end" : 1.800000,
+ *         "phone_end" : [1.440000, 1.500000, 1.590000, 1.680000, 1.800000],
+ *         "phone_label" : ["S_B", "T_I", "AH1_I", "D_I", "IY0_E"],
+ *         "phone_start" : [1.260000, 1.440000, 1.500000, 1.590000, 1.680000],
+ *         "start" : 1.260000,
+ *         "word" : "STUDY"
+ *       }, {
+ *         "conf" : 1.000000,
+ *         "end" : 1.860000,
+ *         "phone_end" : [1.860000],
+ *         "phone_label" : ["AH0_S"],
+ *         "phone_start" : [1.800000],
+ *         "start" : 1.800000,
+ *         "word" : "A"
+ *       }, {
+ *         "conf" : 1.000000,
+ *         "end" : 2.190000,
+ *         "phone_end" : [1.980000, 2.100000, 2.190000],
+ *         "phone_label" : ["L_B", "AA1_I", "T_E"],
+ *         "phone_start" : [1.860000, 1.980000, 2.100000],
+ *         "start" : 1.860000,
+ *         "word" : "LOT"
+ *       }, {
+ *         "conf" : 1.000000,
+ *         "end" : 2.880000,
+ *         "phone_end" : [2.880000],
+ *         "phone_label" : ["SIL"],
+ *         "phone_start" : [2.190000],
+ *         "start" : 2.190000,
+ *         "word" : "<eps>"
+ *       }],
+ *     "text" : " THE STUDENT'S STUDY A LOT"
+ *   }
+ * </pre>
+ *
+ * If configured with "words" option then result is same word-level MBR results. See vosk_recognizer_result() 
+ * </pre>
+ * * @param result_opts - result options to determine which recognition results to return
+ */
+void vosk_recognizer_set_result_options(VoskRecognizer *recognizer, const char *result_opts);
 
 /** Enables words with times in the output
  *


### PR DESCRIPTION
This is to add an ability to generate phone labels and timestamps in the Vosk recognizer output
- Updated model.cc to read phone symbol table (i.e. phones.txt)
- Phone table should be added under ("/graph/phones.txt") in your model directory following standard Kaldi convention
-  Updated Kaldi recognizer script to compute phoneme labels and timestamps and add them to the json output
- Adds phone label, start and end timestamps in the word-level results _only_ if you provide the phone symbol table. If you do not provide the phone symbol table then the recognizer will only generate the existing word-level features.
- Prints silence words along with the corresponding phone information. "Gaps" or silences with duration of 0 seconds duration that don't have corresponding phone information are filtered out. 
- MBR decoding is disabled only for phone information extraction so that the outputs align but if you don't need phone output then you will be able to get word level result from MBR

Output looks like
```{
  "result" : [{
      "conf" : 0.997802,
      "end" : 0.450000,
      "phone_end" : [0.450000],
      "phone_label" : ["SIL"],
      "phone_start" : [0.000000],
      "start" : 0.000000,
      "word" : "<eps>"
    }, {
      "conf" : 0.997153,
      "end" : 0.600000,
      "phone_end" : [0.540000, 0.600000],
      "phone_label" : ["DH_B", "AH1_E"],
      "phone_start" : [0.450000, 0.540000],
      "start" : 0.450000,
      "word" : "THE"
    }, {
      "conf" : 0.553237,
      "end" : 1.200000,
      "phone_end" : [0.720000, 0.810000, 0.870000, 0.930000, 0.990000, 1.080000, 1.110000, 1.200000],
      "phone_label" : ["S_B", "T_I", "UW1_I", "D_I", "AH0_I", "N_I", "T_I", "S_E"],
      "phone_start" : [0.600000, 0.720000, 0.810000, 0.870000, 0.930000, 0.990000, 1.080000, 1.110000],
      "start" : 0.600000,
      "word" : "STUDENT'S"
    }, {
      "conf" : 0.922575,
      "end" : 1.260000,
      "phone_end" : [1.260130],
      "phone_label" : ["SIL"],
      "phone_start" : [1.200130],
      "start" : 1.200130,
      "word" : "<eps>"
    }, {
      "conf" : 1.000000,
      "end" : 1.800000,
      "phone_end" : [1.440000, 1.500000, 1.590000, 1.680000, 1.800000],
      "phone_label" : ["S_B", "T_I", "AH1_I", "D_I", "IY0_E"],
      "phone_start" : [1.260000, 1.440000, 1.500000, 1.590000, 1.680000],
      "start" : 1.260000,
      "word" : "STUDY"
    }, {
      "conf" : 1.000000,
      "end" : 1.860000,
      "phone_end" : [1.860000],
      "phone_label" : ["AH0_S"],
      "phone_start" : [1.800000],
      "start" : 1.800000,
      "word" : "A"
    }, {
      "conf" : 1.000000,
      "end" : 2.190000,
      "phone_end" : [1.980000, 2.100000, 2.190000],
      "phone_label" : ["L_B", "AA1_I", "T_E"],
      "phone_start" : [1.860000, 1.980000, 2.100000],
      "start" : 1.860000,
      "word" : "LOT"
    }, {
      "conf" : 1.000000,
      "end" : 2.880000,
      "phone_end" : [2.880000],
      "phone_label" : ["SIL"],
      "phone_start" : [2.190000],
      "start" : 2.190000,
      "word" : "<eps>"
    }],
  "text" : " THE STUDENT'S STUDY A LOT"
}
```