### PR TITLE
Subtitles require word times

### DIFF
--- a/python/example/test_webvtt.py
+++ b/python/example/test_webvtt.py
@@ -18,6 +18,7 @@ if not os.path.exists('model'):
 sample_rate = 16000
 model = Model('model')
 rec = KaldiRecognizer(model, sample_rate)
+rec.SetWords(True)
 
 WORDS_PER_LINE = 7
 


### PR DESCRIPTION
This is a port of the recent addition of commit 7ccf743, adding
`KaldiRecognizer.SetWords(True)` to the other examples dealing with
subtitles to the WebVTT example.

Without this, the example will not work with the most recent `vosk`
(0.3.30) Python package.

---

Unfortunately, it seems that I was a bit late when submitting the WebVTT example and I was still working with an older version of the Vosk Python package. Sorry!