### PR TITLE
Added missing cuda lib to Vosk compilation flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -75,7 +75,7 @@ endif
 
 ifeq ($(HAVE_CUDA), 1)
     CFLAGS+=-DHAVE_CUDA=1 -I$(CUDA_ROOT)/include
-    LIBS+=-L$(CUDA_ROOT)/lib64 -lcublas -lcusparse -lcudart -lcurand -lcufft -lcusolver -lnvToolsExt
+    LIBS+=-L$(CUDA_ROOT)/lib64 -lcuda -lcublas -lcusparse -lcudart -lcurand -lcufft -lcusolver -lnvToolsExt
 endif
 
 all: libvosk.$(EXT)


### PR DESCRIPTION
On the latest build, `-lcuda` flag absence caused startup failures in Docker with CUDA support.
```shell
vosk_1  | Traceback (most recent call last):
vosk_1  |   File "./asr_server.py", line 11, in <module>
vosk_1  |     from vosk import Model, SpkModel, KaldiRecognizer, GpuInit
vosk_1  |   File "/usr/local/lib/python3.8/dist-packages/vosk-0.3.32-py3.8.egg/vosk/__init__.py", line 21, in <module>
vosk_1  |     _c = open_dll()
vosk_1  |   File "/usr/local/lib/python3.8/dist-packages/vosk-0.3.32-py3.8.egg/vosk/__init__.py", line 15, in open_dll
vosk_1  |     return _ffi.dlopen(os.path.join(dlldir, "libvosk.so"))
vosk_1  | OSError: cannot load library '/usr/local/lib/python3.8/dist-packages/vosk-0.3.32-py3.8.egg/vosk/libvosk.so': /usr/local/lib/python3.8/dist-packages/vosk-0.3.32-py3.8.egg/vosk/libvosk.so: undefined symbol: cuMemGetInfo_v2
```