### PR TITLE
Output correct SRT format using milliseconds (NodeJS SRT example)

### DIFF
--- a/nodejs/demo/test_srt.js
+++ b/nodejs/demo/test_srt.js
@@ -46,8 +46,8 @@ ffmpeg_run.on('exit', code => {
             subs.push({
                 type: 'cue',
                 data: {
-                start: words[0].start,
-                end: words[0].end,
+                start: words[0].start * 1000,
+                end: words[0].end * 1000,
                 text: words[0].word
                 }
             });
@@ -61,8 +61,8 @@ ffmpeg_run.on('exit', code => {
                 subs.push({
                     type: 'cue',
                     data: {
-                      start: words[start_index].start,
-                      end: words[i].end,
+                      start: words[start_index].start * 1000,
+                      end: words[i].end * 1000,
                       text: text.slice(0, text.length-1)
                     }
                 });
@@ -74,8 +74,8 @@ ffmpeg_run.on('exit', code => {
             subs.push({
                 type: 'cue',
                 data: {
-                  start: words[start_index].start,
-                  end: words[words.length-1].end,
+                  start: words[start_index].start * 1000,
+                  end: words[words.length-1].end * 1000,
                   text: text
                 }
             });


### PR DESCRIPTION
Currently it outputs SRT with the wrong time information:
```
1
00:00:00,002 --> 00:00:00,004
close your eyes 

2
00:00:00,004 --> 00:00:00,005
why now 

3
00:00:00,006 --> 00:00:00,008
okay good 

4
00:00:00,008 --> 00:00:00,010
what do you see 
```

After this PR you get the correct timing info:
```
1
00:00:02,186 --> 00:00:03,146
email clear 

2
00:00:03,203 --> 00:00:04,013
the rise 

3
00:00:04,883 --> 00:00:07,043
why now okay 

4
00:00:07,426 --> 00:00:08,026
good
```