### PR TITLE
Use org ref-napi and ffi-napi packages

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vosk",
-  "version": "0.3.32",
+  "version": "0.4.0",
   "description": "Node binding for continuous offline voice recoginition with Vosk library.",
   "repository": {
     "type": "git",
@@ -19,9 +19,9 @@
   },
   "dependencies": {
     "async": "^3.2.0",
-    "ffi-napi": "^4.0.3",
+    "ffi-napi": "npm:@alphacep/ffi-napi@4.0.4",
     "mic": "^2.1.2",
-    "ref-napi": ">=2.0.0",
+    "ref-napi": "npm:@alphacep/ref-napi@4.0.1",
     "wav": "^1.0.2"
   }
 }


### PR DESCRIPTION
If everything went smoothly with:
- https://github.com/alphacep/ref-napi/pull/1
- https://github.com/alphacep/node-ffi-napi/pull/1 

However I wonder how you build the `*.so` files to `nodejs/lib` and how you're executing the tests at the moment.
If you explain to me the few steps you're taking to do all the nodejs related stuff, I could help set up the automation pipeline with Github actions.
