### PR TITLE
Docker GPU images build fix

### DIFF
--- a/src/batch_recognizer.cc
+++ b/src/batch_recognizer.cc
@@ -271,5 +271,5 @@ void BatchRecognizer::WaitForCompletion()
 
 int BatchRecognizer::GetNumPendingChunks(uint64_t id)
 {
-    return dynamic_batcher_->GetNumPendingChunks(id);
+    return dynamic_batcher_->GetPendingChunks(id);
 }


### PR DESCRIPTION
Missed with the method name :)

Let me provide some details:
Building from sources will break @ `batch_recognizer.cc` which is used to build CUDA based images.
Building GPU based docker images will fail in that case.