### PR TITLE
use comma instead of equal sign in `rpath` linker opts

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,5 +1,5 @@
 CFLAGS=-I../src
-LDFLAGS=-L../src -lvosk -ldl -lpthread -Wl,-rpath=../src
+LDFLAGS=-L../src -lvosk -ldl -lpthread -Wl,-rpath,../src
 
 all: test_vosk test_vosk_speaker
 


### PR DESCRIPTION
Using `=` for linker options is a GNU extension which doesn't work with
clang.

Using `,` should work for both gcc and clang.

See https://github.com/alphacep/vosk-api/issues/960
