### PR TITLE
Specify device to get microphone input

### DIFF
--- a/nodejs/demo/test_microphone.js
+++ b/nodejs/demo/test_microphone.js
@@ -18,7 +18,8 @@ const rec = new vosk.Recognizer({model: model, sampleRate: SAMPLE_RATE});
 var micInstance = mic({
     rate: String(SAMPLE_RATE),
     channels: '1',
-    debug: false
+    debug: false,
+    device: 'default',    
 });
 
 var micInputStream = micInstance.getAudioStream();


### PR DESCRIPTION
Hi, thank you for the great library. Vosk is very promising!

I found that the sample code for Node.js microphone input doesn't work without modifying the code. It could emit the following error:

```
Received Info: arecord: main:831: audio open error: Device or resource busy
```

Device: Linux (Arch Linux, with Pipewire)

A current workaround is to specify `default` to `mic` instance creation. Otherwise, it uses `'plughw:1,0'` which is not suitable especially for Linux users. I think Vosk beginners could be lost here.

https://github.com/ashishbajaj99/mic/blob/d06afa6f47389529ea5f4637a4571f537757bf8a/lib/mic.js#L15

Hope this PR helps.