### PR TITLE
new output type json for gecko project

### DIFF
--- a/python/vosk/transcriber/transcriber.py
+++ b/python/vosk/transcriber/transcriber.py
@@ -94,6 +94,18 @@ class Transcriber:
             for part in result:
                 if part["text"] != "":
                     processed_result += part["text"] + "\n"
+
+        elif self.args.output_type == "json":
+            monologues = {"schemaVersion":"2.0", "monologues":[]}
+            for _, res in enumerate(result):
+                if not "result" in res:
+                    continue
+                monologue = { "speaker": {"id": "unknown", "name": None}, "start": 0, "end": 0, "terms": []}
+                monologue["start"] = res["result"][0]["start"]
+                monologue["end"] = res["result"][-1]["end"]
+                monologue["terms"] = [{"confidence": t["conf"], "start": t["start"], "end": t["end"], "text": t["word"], "type": "WORD" } for t in res["result"]]
+                monologues["monologues"].append(monologue)
+            processed_result = json.dumps(monologues)
         return processed_result
 
     def resample_ffmpeg(self, infile):


### PR DESCRIPTION
add a output type `json` to get output file compatible with transcription file format for the gecko project annotation https://github.com/gong-io/gecko
The output type could be named more specifically as `gecko` or `json-gecko` as you preferred 