### PR TITLE
Add OPENBLAS_NO_F2C math library option

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,7 @@ CUDA_ROOT?=/usr/local/cuda
 USE_SHARED?=0
 # Math libraries
 HAVE_OPENBLAS_CLAPACK?=1
+HAVE_OPENBLAS_NO_F2C?=0
 HAVE_MKL?=0
 HAVE_ACCELERATE=0
 HAVE_CUDA?=0
@@ -77,6 +78,18 @@ ifeq ($(HAVE_OPENBLAS_CLAPACK), 1)
             $(OPENBLAS_ROOT)/lib/libf2c.a
     else
         LDFLAGS += -lopenblas -llapack -lblas -lf2c
+    endif
+endif
+
+ifeq ($(HAVE_OPENBLAS_NO_F2C), 1)
+    CFLAGS += -I$(OPENBLAS_ROOT)/include
+    ifeq ($(USE_SHARED), 0)
+        LIBS += \
+            $(OPENBLAS_ROOT)/lib/libopenblas.a \
+            $(OPENBLAS_ROOT)/lib/liblapack.a \
+            $(OPENBLAS_ROOT)/lib/libblas.a
+    else
+        LDFLAGS += -lopenblas -llapack -lblas
     endif
 endif
 


### PR DESCRIPTION
This patch allows building with lapack instead of clapack.
Without this it fails to link f2c which lapack does not have or need.
I have also made a pull request for your kaldi: https://github.com/alphacep/kaldi/pull/5

This helps on distros like Void Linux where there is a lapack package but not a clapack package.
