### PR TITLE
vosk-transcriber: fix JSON output

### DIFF
--- a/python/vosk/transcriber/transcriber.py
+++ b/python/vosk/transcriber/transcriber.py
@@ -99,7 +99,7 @@ class Transcriber:
             monologues = {"schemaVersion":"2.0", "monologues":[], "text":[]}
             for part in result:
                 if part["text"] != "":
-                    monologue["text"] += part["text"]
+                    monologues["text"] += [part["text"]]
             for _, res in enumerate(result):
                 if not "result" in res:
                     continue


### PR DESCRIPTION
The variable name was incorrect. This led to an error when the output was written. Also the result of appending a string to an array is that each character of the string becomes a separate element in the array. Appending the string as a single array element is much more useful.