### PR TITLE
Fix vosk-transcriber cli json format

### DIFF
--- a/python/vosk/transcriber/transcriber.py
+++ b/python/vosk/transcriber/transcriber.py
@@ -99,7 +99,7 @@ class Transcriber:
             monologues = {"schemaVersion":"2.0", "monologues":[], "text":[]}
             for part in result:
                 if part["text"] != "":
-                    monologue["text"] += part["text"]
+                    monologues["text"] += part["text"]
             for _, res in enumerate(result):
                 if not "result" in res:
                     continue


### PR DESCRIPTION
Fix error UnboundLocalError: local variable 'monologue' referenced before assignment in transcriber.py line 102

`vosk-transcriber -i test.wav -o test.json -t json -l en-gb`

> Traceback (most recent call last):
> File "/usr/local/bin/vosk-transcriber", line 8, in
> sys.exit(main())
> File "/usr/local/lib/python3.10/dist-packages/vosk/transcriber/cli.py", line 86, in main
> transcriber.process_task_list(task_list)
> File "/usr/local/lib/python3.10/dist-packages/vosk/transcriber/transcriber.py", line 193, in process_task_list
> self.process_task_list_pool(task_list)
> File "/usr/local/lib/python3.10/dist-packages/vosk/transcriber/transcriber.py", line 189, in process_task_list_pool
> pool.map(self.pool_worker, task_list)
> File "/usr/lib/python3.10/multiprocessing/pool.py", line 367, in map
> return self._map_async(func, iterable, mapstar, chunksize).get()
> File "/usr/lib/python3.10/multiprocessing/pool.py", line 774, in get
> raise self._value
> File "/usr/lib/python3.10/multiprocessing/pool.py", line 125, in worker
> result = (True, func(*args, **kwds))
> File "/usr/lib/python3.10/multiprocessing/pool.py", line 48, in mapstar
> return list(map(*args))
> File "/usr/local/lib/python3.10/dist-packages/vosk/transcriber/transcriber.py", line 168, in pool_worker
> processed_result = self.format_result(result)
> File "/usr/local/lib/python3.10/dist-packages/vosk/transcriber/transcriber.py", line 102, in format_result
> monologue["text"] += part["text"]
> UnboundLocalError: local variable 'monologue' referenced before assignment