### PR TITLE
Set number of OpenBLAS threads

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,7 @@ else
 endif
 
 ifeq ($(HAVE_OPENBLAS_CLAPACK), 1)
-    CFLAGS += -I$(OPENBLAS_ROOT)/include
+    CFLAGS += -DHAVE_OPENBLAS_CLAPACK=1 -I$(OPENBLAS_ROOT)/include
     ifeq ($(USE_SHARED), 0)
         LIBS += \
             $(OPENBLAS_ROOT)/lib/libopenblas.a \

--- a/src/model.cc
+++ b/src/model.cc
@@ -24,9 +24,10 @@
 #include <fst/matcher-fst.h>
 #include <fst/extensions/ngram/ngram-fst.h>
 
-
+#ifdef HAVE_OPENBLAS_CLAPACK
+#include <cblas.h>
+#endif
 #ifdef HAVE_MKL
-// We need to set num threads
 #include <mkl.h>
 #endif
 
@@ -113,6 +114,9 @@ Model::Model(const char *model_path) : model_path_str_(model_path) {
 
     SetLogHandler(KaldiLogHandler);
 
+#ifdef HAVE_OPENBLAS_CLAPACK
+    openblas_set_num_threads(1);
+#endif
 #ifdef HAVE_MKL
     mkl_set_num_threads(1);
 #endif


### PR DESCRIPTION
This sets the number of openblas threads in case openblas wasn't compiled with `USE_LOCKING=1 USE_THREAD=0`.

This slightly nicer version is untested, but simply adding the #include and `openblas_set_num_threads(1);` is what I patched for Alpine.