### PR TITLE
add SetPause (replacing SetEpMode)

### DIFF
--- a/go/vosk.go
+++ b/go/vosk.go
@@ -109,6 +109,11 @@ func (r *VoskRecognizer) SetGrm(grammar string) {
 	C.vosk_recognizer_set_grm(r.rec, cgrammar)
 }
 
+// SetPause sets the duration of silence which terminates a result.
+func (r *VoskRecognizer) SetPause(seconds float64) {
+	C.vosk_recognizer_set_pause(r.rec, C.float(seconds))
+}
+
 // SetMaxAlternatives configures the recognizer to output n-best results.
 func (r *VoskRecognizer) SetMaxAlternatives(maxAlternatives int) {
 	C.vosk_recognizer_set_max_alternatives(r.rec, C.int(maxAlternatives))

--- a/python/vosk/__init__.py
+++ b/python/vosk/__init__.py
@@ -3,7 +3,6 @@ import sys
 import srt
 import datetime
 import json
-import enum
 
 import requests
 from urllib.request import urlretrieve
@@ -142,11 +141,6 @@ class SpkModel:
     def __del__(self):
         _c.vosk_spk_model_free(self._handle)
 
-class EpMode(enum.Enum):
-    DEFAULT = 0
-    SHORT = 1
-    LONG = 2
-
 class KaldiRecognizer:
 
     def __init__(self, *args):
@@ -179,8 +173,8 @@ class KaldiRecognizer:
     def SetNLSML(self, enable_nlsml):
         _c.vosk_recognizer_set_nlsml(self._handle, 1 if enable_nlsml else 0)
 
-    def SetEpMode(self, mode):
-        _c.vosk_recognizer_set_ep_mode(self._handle, mode.value)
+    def SetPause(self, seconds):
+        _c.vosk_recognizer_set_pause(self._handle, seconds)
 
     def SetSpkModel(self, spk_model):
         _c.vosk_recognizer_set_spk_model(self._handle, spk_model._handle)

--- a/src/recognizer.cc
+++ b/src/recognizer.cc
@@ -220,24 +220,13 @@ void Recognizer::SetNLSML(bool nlsml)
     nlsml_ = nlsml;
 }
 
-void Recognizer::SetEpMode(int mode)
+void Recognizer::SetPause(float seconds)
 {
-    float scale = 1.0;
-    switch(mode) {
-        case 1:
-           scale = 0.75;
-           break;
-        case 2:
-           scale = 1.50;
-           break;
-        default:
-           scale = 4.0;
-    }
-    KALDI_LOG << "Endpointer Scale " << scale;
+    KALDI_LOG << "Pause Duration " << seconds;
     endpoint_config_ = model_->endpoint_config_;
-    endpoint_config_.rule2.min_trailing_silence *= scale;
-    endpoint_config_.rule3.min_trailing_silence *= scale;
-    endpoint_config_.rule4.min_trailing_silence *= scale;
+    endpoint_config_.rule2.min_trailing_silence = seconds * 0.5;
+    endpoint_config_.rule3.min_trailing_silence = seconds * 0.75;
+    endpoint_config_.rule4.min_trailing_silence = seconds;
 }
 
 void Recognizer::SetSpkModel(SpkModel *spk_model)

--- a/src/recognizer.h
+++ b/src/recognizer.h
@@ -52,7 +52,7 @@ class Recognizer {
         void SetWords(bool words);
         void SetPartialWords(bool partial_words);
         void SetNLSML(bool nlsml);
-        void SetEpMode(int mode);
+        void SetPause(float seconds);
         bool AcceptWaveform(const char *data, int len);
         bool AcceptWaveform(const short *sdata, int len);
         bool AcceptWaveform(const float *fdata, int len);

--- a/src/vosk_api.cc
+++ b/src/vosk_api.cc
@@ -129,12 +129,12 @@ void vosk_recognizer_set_grm(VoskRecognizer *recognizer, char const *grammar)
     ((Recognizer *)recognizer)->SetGrm(grammar);
 }
 
-void vosk_recognizer_set_ep_mode(VoskRecognizer *recognizer, VoskEpMode mode)
+void vosk_recognizer_set_pause(VoskRecognizer *recognizer, float seconds)
 {
     if (recognizer == nullptr) {
        return;
     }
-    ((Recognizer *)recognizer)->SetEpMode(mode);
+    ((Recognizer *)recognizer)->SetPause(seconds);
 }
 
 int vosk_recognizer_accept_waveform(VoskRecognizer *recognizer, const char *data, int length)

--- a/src/vosk_api.h
+++ b/src/vosk_api.h
@@ -217,18 +217,11 @@ void vosk_recognizer_set_partial_words(VoskRecognizer *recognizer, int partial_w
  */
 void vosk_recognizer_set_nlsml(VoskRecognizer *recognizer, int nlsml);
 
-typedef enum VoskEpMode {
-    VOSK_EP_ANSWER_DEFAULT = 0,
-    VOSK_EP_ANSWER_SHORT = 1,
-    VOSK_EP_ANSWER_LONG = 2,
-} VoskEpMode;
-
-/**
- * Set endpointer scaling factor
+/** Set the duration of silence which terminates a result
  *
- * @param mode - Endpointer mode
- **/
-void vosk_recognizer_set_ep_mode(VoskRecognizer *recognizer,  VoskEpMode mode);
+ * @param seconds - float value
+ */
+void vosk_recognizer_set_pause(VoskRecognizer *recognizer, float seconds);
 
 /** Accept voice data
  *


### PR DESCRIPTION
This adds a SetSilence function with a float argument to set the min_trailing_silence values. It's simpler yet more useful than SetEpMode, which is limited to an enum of only DEFAULT/SHORT/LONG. Also, there seemed to be a bug in that calling SetEpMode repeatedly would keep scaling the values further.

I based the rule{2,3,4} constants off the values from the small-en-us model.

SetSilence lets me, for example, set the min_trailing_silence values to 0.0 for very responsive results for gaming ([video](https://peertube.tv/w/q97YgLcPT7xxp5sXzWr8D5?start=1m34s)).

Closes: https://github.com/alphacep/vosk-api/issues/1348

Thank you!