### PR TITLE
go: do not include libdl if building on Windows

### DIFF
--- a/go/vosk.go
+++ b/go/vosk.go
@@ -1,7 +1,8 @@
 package vosk
 
 // #cgo CPPFLAGS: -I ${SRCDIR}/../src
-// #cgo LDFLAGS: -L ${SRCDIR}/../src -lvosk -ldl -lpthread
+// #cgo !windows LDFLAGS: -L ${SRCDIR}/../src -lvosk -ldl -lpthread
+// #cgo windows LDFLAGS: -L ${SRCDIR}/../src -lvosk -lpthread
 // #include <stdlib.h>
 // #include <vosk_api.h>
 import "C"


### PR DESCRIPTION
Allows Go programs using this module to be built on Windows