### PR TITLE
Kaldi remove lm target because rnnlm has lm

### DIFF
--- a/android/lib/build-vosk.sh
+++ b/android/lib/build-vosk.sh
@@ -118,7 +118,7 @@ CXX=$CXX AR=$AR RANLIB=$RANLIB CXXFLAGS="$ARCHFLAGS -O3 -DFST_NO_DYNAMIC_LINKING
     --fst-root=${WORKDIR}/local --fst-version=${OPENFST_VERSION}
 make -j 8 depend
 cd $WORKDIR/kaldi/src
-make -j 8 online2 lm rnnlm
+make -j 8 online2 rnnlm
 
 # Vosk-api
 cd $WORKDIR

--- a/travis/Dockerfile.dockcross
+++ b/travis/Dockerfile.dockcross
@@ -45,5 +45,5 @@ RUN cd /opt \
     && sed -i "s:TARGET_ARCH=\"\`uname -m\`\":TARGET_ARCH=$(echo $CROSS_TRIPLE|cut -d - -f 1):g" configure \
     && sed -i "s: -O1 : -O3 :g" makefiles/linux_openblas_arm.mk \
     && ./configure --mathlib=OPENBLAS_CLAPACK --shared --use-cuda=no \
-    && make -j 10 online2 lm rnnlm \
+    && make -j 10 online2 rnnlm \
     && find /opt/kaldi -name "*.o" -exec rm {} \;

--- a/travis/Dockerfile.dockcross-manylinux
+++ b/travis/Dockerfile.dockcross-manylinux
@@ -35,5 +35,5 @@ RUN cd /opt \
     && sed -i "s:TARGET_ARCH=\"\`uname -m\`\":TARGET_ARCH=$(echo $CROSS_TRIPLE|cut -d - -f 1):g" configure \
     && sed -i "s: -O1 : -O3 :g" makefiles/linux_openblas_arm.mk \
     && ./configure --mathlib=OPENBLAS_CLAPACK --shared --use-cuda=no \
-    && make -j 10 online2 lm rnnlm \
+    && make -j 10 online2 rnnlm \
     && find /opt/kaldi -name "*.o" -exec rm {} \;

--- a/travis/Dockerfile.manylinux
+++ b/travis/Dockerfile.manylinux
@@ -30,5 +30,5 @@ RUN cd /opt \
     && ./configure --mathlib=OPENBLAS_CLAPACK --shared --use-cuda=no \
     && sed -i 's:-msse -msse2:-msse -msse2:g' kaldi.mk \
     && sed -i 's: -O1 : -O3 :g' kaldi.mk \
-    && make -j $(nproc) online2 lm rnnlm \
+    && make -j $(nproc) online2 rnnlm \
     && find /opt/kaldi -name "*.o" -exec rm {} \;

--- a/travis/Dockerfile.manylinux-mkl
+++ b/travis/Dockerfile.manylinux-mkl
@@ -27,5 +27,5 @@ RUN cd /opt \
     && ./configure --mathlib=MKL --shared --use-cuda=no \
     && sed -i 's:-msse -msse2:-msse -msse2 -mavx -mavx2:g' kaldi.mk \
     && sed -i 's: -O1 : -O3 :g' kaldi.mk \
-    && make -j $(nproc) online2 lm rnnlm \
+    && make -j $(nproc) online2 rnnlm \
     && find /opt/kaldi -name "*.o" -exec rm {} \;

--- a/travis/Dockerfile.win
+++ b/travis/Dockerfile.win
@@ -62,4 +62,4 @@ RUN cd /opt/kaldi \
         --host=x86_64-w64-mingw32 --openblas-clapack-root=/opt/kaldi/local \
         --fst-root=/opt/kaldi/local --fst-version=1.8.0 \
     && make depend -j \
-    && make -j $(nproc) online2 lm rnnlm
+    && make -j $(nproc) online2 rnnlm

--- a/travis/Dockerfile.win32
+++ b/travis/Dockerfile.win32
@@ -61,4 +61,4 @@ RUN cd /opt/kaldi \
         --host=i686-w64-mingw32 --openblas-clapack-root=/opt/kaldi/local \
         --fst-root=/opt/kaldi/local --fst-version=1.8.0 \
     && make depend -j \
-    && make -j $(nproc) online2 lm rnnlm
+    && make -j $(nproc) online2 rnnlm


### PR DESCRIPTION
Target rnnlm already includes lm, so no need to specify lm anymore