### PR TITLE
added recognizer resource releasing

### DIFF
--- a/android/lib/src/main/java/org/vosk/android/SpeechService.java
+++ b/android/lib/src/main/java/org/vosk/android/SpeechService.java
@@ -22,6 +22,7 @@ import android.os.Looper;
 import android.annotation.SuppressLint;
 
 import org.vosk.Recognizer;
+import org.vosk.LibVosk;
 import java.io.IOException;
 
 /**
@@ -141,6 +142,9 @@ public class SpeechService {
      * Shutdown the recognizer and release the recorder
      */
     public void shutdown() {
+        if (recognizer != null) {
+            LibVosk.vosk_recognizer_free(recognizer.getPointer())
+        }
         recorder.release();
     }
 


### PR DESCRIPTION
Used recognizer in my project, but found with help of profiler that if you call SpeechService.shutdown() method it doesn't release recognizer resources which may cause big memory leaks (150 mb in my case) each time you start listening for recognition