### PR TITLE
Fix: Raise exception in Node.js binding when model creation fails (#716)

### DIFF
--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -130,6 +130,9 @@ class Model {
          * @type {unknown}
          */
         this.handle = libvosk.vosk_model_new(modelPath);
+        if (!this.handle) {
+            throw new Error('Failed to create a model.');
+        }
     }
 
     /**
@@ -163,6 +166,9 @@ class SpeakerModel {
          * @type {unknown}
          */
         this.handle = libvosk.vosk_spk_model_new(modelPath);
+        if (!this.handle) {
+            throw new Error('Failed to create a speaker model.');
+        }
     }
 
     /**
@@ -237,6 +243,10 @@ class Recognizer {
             : hasOwnProperty(param, 'grammar')
                 ? libvosk.vosk_recognizer_new_grm(model.handle, sampleRate, JSON.stringify(param.grammar))
                 : libvosk.vosk_recognizer_new(model.handle, sampleRate);
+
+        if (!this.handle) {
+            throw new Error('Failed to create a recognizer.');
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
This PR fixes Issue #716 by ensuring that an exception is raised when the following functions fail in the Node.js binding and return `null`:

- `vosk_model_new()` (in `Model` constructor)
- `vosk_spk_model_new()` (in `SpeakerModel` constructor)
- `vosk_recognizer_new_spk()`, `vosk_recognizer_new_grm()`, or `vosk_recognizer_new()` (in `Recognizer` constructor)

## Changes Made
- Added `null` checks in the constructors of `Model`, `SpeakerModel`, and `Recognizer` to throw an error when the respective function calls fail.

## Testing
- Verified that the model loads correctly when a valid path is provided.
- Ensured that an error is thrown when an invalid path is used.
- **Tested these changes in a live project:** [voicebot](https://github.com/MdHusainThekiya/voicebot)  

## Related Issue
Closes #716