### PR TITLE
fix(python): Add an error check for tot_samples to prevent zero division error

### DIFF
--- a/python/vosk/transcriber/transcriber.py
+++ b/python/vosk/transcriber/transcriber.py
@@ -179,7 +179,8 @@ class Transcriber:
                 fh.write(processed_result)
         else:
             print(processed_result)
-
+        if tot_samples == 0:
+            raise ValueError("Value of total samples is 0. Please check if input is an audio and try again")
         elapsed = timer() - start_time
         logging.info("Execution time: {:.3f} sec; "\
                 "xRT {:.3f}".format(elapsed, float(elapsed) * (2 * SAMPLE_RATE) / tot_samples))


### PR DESCRIPTION
As I shared in #1728, it throws such error if the input is not a valid audio file.

I have added this check to alert user about it, and prevent division by zero error, until the issue is fixed.

