### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/alphacep/vosk-api?lang=de) | 
+[Español](https://www.readme-i18n.com/alphacep/vosk-api?lang=es) | 
+[français](https://www.readme-i18n.com/alphacep/vosk-api?lang=fr) | 
+[日本語](https://www.readme-i18n.com/alphacep/vosk-api?lang=ja) | 
+[한국어](https://www.readme-i18n.com/alphacep/vosk-api?lang=ko) | 
+[Português](https://www.readme-i18n.com/alphacep/vosk-api?lang=pt) | 
+[Русский](https://www.readme-i18n.com/alphacep/vosk-api?lang=ru) | 
+[中文](https://www.readme-i18n.com/alphacep/vosk-api?lang=zh)
+
 # Vosk Speech Recognition Toolkit
 
 Vosk is an offline open source speech recognition toolkit. It enables


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.