### PR TITLE
Fix typo in encoding in transcribe_scp.py

### DIFF
--- a/python/test/transcribe_scp.py
+++ b/python/test/transcribe_scp.py
@@ -28,7 +28,7 @@ def recognize(line):
 
 def main():
     p = Pool(8)
-    texts = p.map(recognize, open(sys.argv[1], encoding="uft-8").readlines())
+    texts = p.map(recognize, open(sys.argv[1], encoding="utf-8").readlines())
     print ("\n".join(texts))
 
 main()


### PR DESCRIPTION
Fix typo in encoding in transcribe_scp.py. uft-8 -> utf-8
Test script of python was not working 