### PR TITLE
Add consumer ProGuard rules to Vosk Android AAR (JNA keep rules)

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -12,6 +12,7 @@ android {
         versionName = version
         archivesBaseName = archiveName
         ndkVersion = "28.2.13676358"
+        consumerProguardFiles 'consumer-rules.pro'
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/lib/consumer-rules.pro
+++ b/android/lib/consumer-rules.pro
@@ -1,0 +1,4 @@
+# JNA rules - required for Vosk to work with R8/ProGuard minification
+-keep class com.sun.jna.** { *; }
+-keepclassmembers class * extends com.sun.jna.** { public *; }
+-dontwarn java.awt.**


### PR DESCRIPTION
Vosk Android uses JNA; minified apps may need to keep JNA classes/members.

The demo app currently documents these rules, but library consumers don't automatically get them.

This change adds `consumer-rules.pro` and wires it via `consumerProguardFiles` so Gradle/AGP users get the rules automatically when minifying.

### Changes
- Added `android/lib/consumer-rules.pro` with JNA keep rules
- Updated `android/lib/build.gradle` to include `consumerProguardFiles 'consumer-rules.pro'`