### PR TITLE
Add getAudioSessionId() getter to SpeechService

### DIFF
--- a/android/lib/src/main/java/org/vosk/android/SpeechService.java
+++ b/android/lib/src/main/java/org/vosk/android/SpeechService.java
@@ -137,6 +137,19 @@ public class SpeechService {
         return stopRecognizerThread();
     }
 
+
+    /**
+     * Returns the audio session ID of the underlying {@link AudioRecord}.
+     * <p>
+     * The session ID can be used to attach audio effects such as
+     * {@link android.media.audiofx.NoiseSuppressor} to the recording session.
+     *
+     * @return audio session ID, or {@link AudioRecord#ERROR} if unavailable
+     */
+    public int getAudioSessionId() {
+        return recorder.getAudioSessionId();
+    }
+
     /**
      * Shutdown the recognizer and release the recorder
      */


### PR DESCRIPTION
Closes #1583

## Problem

`SpeechService` creates an `AudioRecord` internally, but never exposes its audio session ID. This makes it impossible for callers to attach Android `AudioEffect` subclasses — most notably `NoiseSuppressor` and `AcousticEchoCanceler` — without resorting to subclassing or reflection.

`NoiseSuppressor` (and siblings) require the session ID at construction time:

```java
if (NoiseSuppressor.isAvailable()) {
    NoiseSuppressor ns = NoiseSuppressor.create(speechService.getAudioSessionId());
    ns.setEnabled(true);
}
```

## Change

Add a single public getter in `SpeechService`:

```java
public int getAudioSessionId() {
    return recorder.getAudioSessionId();
}
```

`AudioRecord.getAudioSessionId()` is available since API 16 (the same minimum level Vosk targets) and is safe to call at any point after the `AudioRecord` is constructed.

## Testing

No behavioural change — this is a pure read accessor over an existing field.