### PR TITLE
Add SpeechService constructor accepting a caller-supplied AudioRecord

### DIFF
--- a/android/lib/src/main/java/org/vosk/android/SpeechService.java
+++ b/android/lib/src/main/java/org/vosk/android/SpeechService.java
@@ -66,6 +66,51 @@ public class SpeechService {
         }
     }
 
+    /**
+     * Creates speech service with a caller-supplied {@link AudioRecord}.
+     * <p>
+     * Use this when you need to control the audio input device - for example,
+     * to pin recording to the built-in microphone when an external USB device
+     * without a microphone is present:
+     * <pre>
+     * AudioRecord recorder = new AudioRecord.Builder()
+     *         .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+     *         .setAudioFormat(format)
+     *         .build();
+     * if (Build.VERSION.SDK_INT >= 28) {
+     *     AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+     *     for (AudioDeviceInfo d : am.getDevices(AudioManager.GET_DEVICES_INPUTS)) {
+     *         if (d.getType() == AudioDeviceInfo.TYPE_BUILTIN_MIC) {
+     *             recorder.setPreferredDevice(d);
+     *             break;
+     *         }
+     *     }
+     * }
+     * SpeechService service = new SpeechService(recognizer, 16000f, recorder);
+     * </pre>
+     * <p>
+     * The caller retains ownership of {@code recorder}: if this constructor
+     * throws, the recorder is <em>not</em> released. Call
+     * {@link AudioRecord#release()} yourself in that case.
+     *
+     * @param recognizer the Vosk recognizer
+     * @param sampleRate sample rate in Hz; must match {@code recorder}'s configuration
+     * @param recorder   a fully-initialised {@link AudioRecord}
+     * @throws IOException if {@code recorder} is in STATE_UNINITIALIZED
+     */
+    public SpeechService(Recognizer recognizer, float sampleRate, AudioRecord recorder)
+            throws IOException {
+        this.recognizer = recognizer;
+        this.sampleRate = (int) sampleRate;
+        this.recorder   = recorder;
+
+        bufferSize = Math.round(this.sampleRate * BUFFER_SIZE_SECONDS);
+
+        if (recorder.getState() == AudioRecord.STATE_UNINITIALIZED) {
+            throw new IOException(
+                    "Failed to initialize recorder. Microphone might be already in use.");
+        }
+    }
 
     /**
      * Starts recognition. Does nothing if recognition is active.


### PR DESCRIPTION
Closes #1991

## Problem

`SpeechService` always creates its own `AudioRecord` using `AudioSource.VOICE_RECOGNITION` with no way to influence device selection. When an external USB device (such as a camera) without a microphone is plugged in, Android may route audio to that device and `SpeechService` fails silently — the `AudioRecord` initialises but produces no audio.

Android has provided a fix for this since API 28 via `AudioRecord.setPreferredDevice()`, but callers have no way to use it through `SpeechService`.

## Change

Add a second constructor overload:

```java
public SpeechService(Recognizer recognizer, float sampleRate, AudioRecord recorder)
        throws IOException
```

The caller builds and configures the `AudioRecord` (including calling `setPreferredDevice()` if needed), then passes it in. The existing `SpeechService(Recognizer, float)` constructor is unchanged.

**Ownership semantics** differ intentionally from the original constructor: because the caller created the recorder, this constructor does _not_ call `recorder.release()` on failure — it throws and leaves cleanup to the caller.

## Example usage

```java
AudioRecord recorder = new AudioRecord.Builder()
        .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
        .setAudioFormat(new AudioFormat.Builder()
                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
                .setSampleRate(16000)
                .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
                .build())
        .build();

if (Build.VERSION.SDK_INT >= 28) {
    AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
    for (AudioDeviceInfo d : am.getDevices(AudioManager.GET_DEVICES_INPUTS)) {
        if (d.getType() == AudioDeviceInfo.TYPE_BUILTIN_MIC) {
            recorder.setPreferredDevice(d);
            break;
        }
    }
}

SpeechService service = new SpeechService(recognizer, 16000f, recorder);
```

## Backward compatibility

Purely additive — no existing constructor or method is modified. All existing call sites continue to compile and behave identically.