### PR TITLE
go: Add SetEndpointerMode

### DIFF
--- a/go/example/test_simple.go
+++ b/go/example/test_simple.go
@@ -32,6 +32,7 @@ func main() {
 		log.Fatal(err)
 	}
 	rec.SetWords(1)
+	rec.SetEndpointerMode(vosk.EndpointerModeDefault)
 
 	file, err := os.Open(filename)
 	if err != nil {

--- a/go/vosk.go
+++ b/go/vosk.go
@@ -125,6 +125,24 @@ func (r *VoskRecognizer) SetPartialWords(words int) {
 	C.vosk_recognizer_set_partial_words(r.rec, C.int(words))
 }
 
+// EndpointerMode controls how aggressively the endpointer decides
+// that an utterance has ended.
+type EndpointerMode int
+
+const (
+	EndpointerModeDefault EndpointerMode = iota
+	EndpointerModeShort
+	EndpointerModeLong
+	EndpointerModeVeryLong
+)
+
+// SetEndpointerMode sets the endpointer mode, trading off latency
+// against how much silence is tolerated before an utterance is
+// considered finished.
+func (r *VoskRecognizer) SetEndpointerMode(mode EndpointerMode) {
+	C.vosk_recognizer_set_endpointer_mode(r.rec, C.VoskEndpointerMode(mode))
+}
+
 // SetEndpointerDelays sets the recognition timeouts, where startMax
 // is the timeout for stopping recognition in case of initial silence
 // (usually around 5), end is the timeout for stopping recognition


### PR DESCRIPTION
The C API exposes `vosk_recognizer_set_endpointer_mode` (`src/vosk_api.h`) to control how aggressively the endpointer decides an utterance has ended, but `go/vosk.go` only wrapped the companion `SetEndpointerDelays` call. The Python, C#, Ruby and Kotlin bindings all expose this mode (`EndpointerMode` / `endpointer_mode=`); the Go binding was the outlier missing it.

This adds an `EndpointerMode` type with the four modes from `vosk_api.h` (`EndpointerModeDefault` / `Short` / `Long` / `VeryLong`, matching the C `VoskEndpointerMode` enum and the Python `EndpointerMode` enum's values 0-3) and a `SetEndpointerMode` method on `VoskRecognizer` that calls the existing C symbol, placed directly above `SetEndpointerDelays` and following its exact pattern. No C/build changes are needed since the Go cgo preamble already includes `vosk_api.h` and links `-lvosk`.

Also calls the new method from `go/example/test_simple.go` so the API is exercised in the example.

### Testing

Ran from the `go/` directory (go1.27.0 darwin/arm64):

- `gofmt -l vosk.go example/test_simple.go` reports only `vosk.go`, and `gofmt -d vosk.go` shows the single reported issue is a pre-existing, untouched line (`func(s *VoskSpkModel) Free()` missing a space, present before this change too) - no formatting issues introduced by this diff.
- `go build .` (the `vosk` library package, no linking required): exit 0, no output.
- `go vet .` (the `vosk` library package): exit 0, no output.
- Regression proof: with `go/vosk.go` reverted to `master` but the example's new `rec.SetEndpointerMode(...)` call left in place, `go vet ./example` fails with `vet: example/test_simple.go:35:6: rec.SetEndpointerMode undefined (type *vosk.VoskRecognizer has no field or method SetEndpointerMode)` (exit 1). With `vosk.go` restored, `go vet ./example` passes with exit 0 and no output.

I could not build or run `go build ./...`, `example`, or `batch_example` - they are main packages that link against `-lvosk`, and no built `libvosk` shared library is available in this environment (building it requires the full Kaldi-based C++ core). This is a pre-existing environment limitation and not caused by this change: `go build ./...` fails identically on unmodified `master` with `ld: library 'vosk' not found`. `go vet` was used instead because it performs full cgo type-checking against the real `vosk_api.h` header without invoking the linker, which is sufficient to validate the new binding's signature and type usage.
