### PR TITLE
go: Add SetNlsml to VoskRecognizer

### DIFF
--- a/go/vosk.go
+++ b/go/vosk.go
@@ -125,6 +125,11 @@ func (r *VoskRecognizer) SetPartialWords(words int) {
 	C.vosk_recognizer_set_partial_words(r.rec, C.int(words))
 }
 
+// SetNlsml enables NLSML output instead of JSON.
+func (r *VoskRecognizer) SetNlsml(nlsml int) {
+	C.vosk_recognizer_set_nlsml(r.rec, C.int(nlsml))
+}
+
 // SetEndpointerDelays sets the recognition timeouts, where startMax
 // is the timeout for stopping recognition in case of initial silence
 // (usually around 5), end is the timeout for stopping recognition


### PR DESCRIPTION
The C API exposes `vosk_recognizer_set_nlsml()` (declared in `src/vosk_api.h`, implemented in `src/recognizer.cc`) and the Python, Java, C#, and Node bindings all wrap it, but the Go binding does not. Go users cannot switch a recognizer to NLSML output without dropping to cgo themselves.

This adds `(*VoskRecognizer).SetNlsml`, following the exact shape of the neighbouring `SetPartialWords` / `SetWords` wrappers in the same file.

Testing: `go build .` on the `go/` package is clean and `gofmt -l vosk.go` reports nothing introduced by this diff. The example binaries under `go/example` cannot be linked here because that requires the prebuilt `libvosk` shared library, which is distributed as a binary release rather than built from this tree, so no runtime test was run against a real model.
